### PR TITLE
Updates to Github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
   workflow_dispatch:
 
 env:
@@ -18,6 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --features std --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --features std --verbose


### PR DESCRIPTION
Changed Github actions:
- Can be invoked through the "Actions" tab
- Actions run on any push or pull request, not just to main
- Running cargo build and test with "std" features